### PR TITLE
Ability to convert all levels to binary file format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 set(SOURCES
 	src/main.cpp
+	src/BinaryFile.cpp
 	src/CYObject.cpp
 	src/FileParser.cpp
 	src/FileWriter.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,14 @@ cmake_minimum_required(VERSION 3.1)
 
 project(cy_parser)
 #Set up the C++ flags
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_LIBRARIES -lstdc++fs)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELEASE "-Ofast")
 
 set(SOURCES
 	src/main.cpp

--- a/src/BinaryFile.cpp
+++ b/src/BinaryFile.cpp
@@ -2,6 +2,10 @@
 
 #include <iostream>
 
+BinaryFileBuffer::BinaryFileBuffer() {
+    m_buffer.reserve(65536);
+}
+
 const char* BinaryFileBuffer::getBuffer() const {
     return m_buffer.data();
 }

--- a/src/BinaryFile.cpp
+++ b/src/BinaryFile.cpp
@@ -1,0 +1,15 @@
+#include "BinaryFile.h"
+
+#include <iostream>
+
+const char* BinaryFileBuffer::getBuffer() const {
+    return m_buffer.data();
+}
+
+size_t BinaryFileBuffer::bufferSize() const{
+    return m_buffer.size();
+}
+
+void BinaryFileBuffer::write(const char* buffer, size_t length) {
+    std::copy(buffer, buffer + length, std::back_insert_iterator(m_buffer));
+}

--- a/src/BinaryFile.h
+++ b/src/BinaryFile.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <vector>
+#include <cstdint>
+#include <string>
+
+using u8 = uint8_t;
+using u16 = uint16_t;
+using u32 = uint32_t;
+
+class BinaryFileBuffer {
+    public:
+        friend BinaryFileBuffer& operator <<(BinaryFileBuffer& buff, u8 n) {
+            auto value = reinterpret_cast<const char*>(&n);
+            buff.write(value, sizeof(u8));
+            return buff;
+        }
+        
+        friend BinaryFileBuffer& operator <<(BinaryFileBuffer& buff, u16 n) {
+            auto value = reinterpret_cast<const char*>(&n);
+            buff.write(value, sizeof(u16));
+            return buff;
+        }
+
+        friend BinaryFileBuffer& operator <<(BinaryFileBuffer& buff, u32 n) {
+            auto value = reinterpret_cast<const char*>(&n);
+            buff.write(value, sizeof(u32));
+            return buff;
+        }
+
+        friend BinaryFileBuffer& operator <<(BinaryFileBuffer& buff, const std::string& s) {
+            buff << (uint32_t)s.size();
+            buff.write(s.c_str(), s.size());
+            return buff;
+        }
+
+        template<typename T>
+        friend BinaryFileBuffer& operator <<(BinaryFileBuffer& buff, const T& object) {
+            object.serialize(buff);
+            return buff;
+        }
+
+        const char* getBuffer() const;
+        size_t      bufferSize() const;
+
+    private:
+        void write(const char* buffer, size_t length);
+        std::vector<char> m_buffer;
+};

--- a/src/BinaryFile.h
+++ b/src/BinaryFile.h
@@ -11,6 +11,8 @@ using u32 = uint32_t;
 
 class BinaryFileBuffer {
     public:
+        BinaryFileBuffer();
+        
         friend BinaryFileBuffer& operator <<(BinaryFileBuffer& buff, u8 n) {
             auto value = reinterpret_cast<const char*>(&n);
             buff.write(value, sizeof(u8));

--- a/src/BinaryFile.h
+++ b/src/BinaryFile.h
@@ -6,6 +6,7 @@
 
 using u8 = uint8_t;
 using u16 = uint16_t;
+using i16 = int16_t;
 using u32 = uint32_t;
 
 class BinaryFileBuffer {
@@ -13,6 +14,12 @@ class BinaryFileBuffer {
         friend BinaryFileBuffer& operator <<(BinaryFileBuffer& buff, u8 n) {
             auto value = reinterpret_cast<const char*>(&n);
             buff.write(value, sizeof(u8));
+            return buff;
+        }
+
+        friend BinaryFileBuffer& operator <<(BinaryFileBuffer& buff, i16 n) {
+            auto value = reinterpret_cast<const char*>(&n);
+            buff.write(value, sizeof(i16));
             return buff;
         }
         

--- a/src/CYObject.cpp
+++ b/src/CYObject.cpp
@@ -26,14 +26,19 @@ void CYObject::verifyPropertyCount(ObjectID id) {
             }
             break;
 
-        case ObjectID::Diamond:
         case ObjectID::Finish:
+            switch (propCount) {
+                case 2:
+                    properties.erase(properties.begin());
+                    break;
+            }
+        case ObjectID::Diamond:
         case ObjectID::Iceman:
         case ObjectID::Ramp:
             switch (propCount) {
                 case 1:
-                addBackProp(properties);
-                break;
+                    addBackProp(properties);
+                    break;
             }
             break;
 

--- a/src/CYObject.cpp
+++ b/src/CYObject.cpp
@@ -113,3 +113,23 @@ ObjectID stringToObjectID(const std::string& objectName) {
     };
     return objects.at(objectName);
 }
+
+void CYFloor::serialize(BinaryFileBuffer& buffer) const {
+    buffer  << vertexA << vertexB << vertexC << vertexD << floor << floor 
+            << (u32)std::stoi(properties[0]) 
+            << (u32)std::stoi(properties[1]) 
+            << (u8 )std::stoi(properties[2]);
+    
+}
+
+void CYWall::serialize(BinaryFileBuffer& buffer) const {
+    buffer  << beginPoint << endPoint << floor
+            << (u32)std::stoi(properties[0]) 
+            << (u32)std::stoi(properties[1]) 
+            << (u8 )std::stoi(properties[2]);
+    
+}
+
+void CYObject::serialize(BinaryFileBuffer& buffer) const {
+    
+}

--- a/src/CYObject.cpp
+++ b/src/CYObject.cpp
@@ -127,15 +127,3 @@ void CYWall::serialize(BinaryFileBuffer& buffer) const {
             << (u32)std::stoul(properties[1]) 
             << (u8 )std::stoi(properties[2]);
 }
-
-
-namespace {
-    void writeSingleObjectHeader(BinaryFileBuffer& buffer, const Position& position, uint8_t floor) {
-        buffer << position << (u8)floor;
-    } 
-} 
-
-
-void serializeObject(BinaryFileBuffer& buffer, CYObject& obj, ObjectID id) {
-    
-}

--- a/src/CYObject.cpp
+++ b/src/CYObject.cpp
@@ -116,20 +116,26 @@ ObjectID stringToObjectID(const std::string& objectName) {
 
 void CYFloor::serialize(BinaryFileBuffer& buffer) const {
     buffer  << vertexA << vertexB << vertexC << vertexD << floor << floor 
-            << (u32)std::stoi(properties[0]) 
-            << (u32)std::stoi(properties[1]) 
-            << (u8 )std::stoi(properties[2]);
-    
+            << (u32)std::stoul(properties[0]) 
+            << (u32)std::stoul(properties[2]) 
+            << (u8 )std::stoi(properties[1]);
 }
 
 void CYWall::serialize(BinaryFileBuffer& buffer) const {
     buffer  << beginPoint << endPoint << floor
-            << (u32)std::stoi(properties[0]) 
-            << (u32)std::stoi(properties[1]) 
+            << (u32)std::stoul(properties[0]) 
+            << (u32)std::stoul(properties[1]) 
             << (u8 )std::stoi(properties[2]);
-    
 }
 
-void CYObject::serialize(BinaryFileBuffer& buffer) const {
+
+namespace {
+    void writeSingleObjectHeader(BinaryFileBuffer& buffer, const Position& position, uint8_t floor) {
+        buffer << position << (u8)floor;
+    } 
+} 
+
+
+void serializeObject(BinaryFileBuffer& buffer, CYObject& obj, ObjectID id) {
     
 }

--- a/src/CYObject.h
+++ b/src/CYObject.h
@@ -33,6 +33,7 @@ enum class ObjectID : uint8_t {
     TriPlatform 	= 22,
     TriWall		    = 23,
     Wall		    = 24,
+    NUM_OBJECTS     = 25,
     
     Theme		    = 250,
     Weather		    = 251,
@@ -89,7 +90,7 @@ struct CYObject {
     void verifyPropertyCount(ObjectID id);
 };
 
-using CYObjectMap = std::unordered_map<ObjectID, std::vector<CYObject>>;
+using CYObjectMap = std::array<std::vector<CYObject>, (int)ObjectID::NUM_OBJECTS>;
 struct CYLevel {
     std::string name;
     std::string creator;
@@ -104,7 +105,7 @@ struct CYLevel {
     std::vector<CYWall> walls;
 
     size_t numObjects(ObjectID id) const {
-        return objects.at(id).size();
+        return objects[(int)id].size();
     }
 };
 

--- a/src/CYObject.h
+++ b/src/CYObject.h
@@ -5,6 +5,8 @@
 #include <map>
 #include <vector>
 
+#include "BinaryFile.h"
+
 enum class ObjectID : uint8_t {
     Chaser		    = 0,
     Crumbs		    = 1,
@@ -43,11 +45,12 @@ enum class ObjectID : uint8_t {
  * 
  */
 struct Position {
-    int16_t x = 0;
+    int x = 0;
     int z = 0;
 
-    int16_t serialize() {
-
+    template<typename Buffer>
+    void serialize(Buffer& buffer) const {
+        buffer << (u16)x << (u16)z;
     }
 };
 
@@ -77,6 +80,15 @@ struct CYWall {
     Position endPoint;
     std::vector<std::string> properties;
     uint8_t floor;
+
+    template<typename Buffer>
+    void serialize(Buffer& buffer) const {
+        buffer << beginPoint << endPoint << floor
+                << (u32)std::stoi(properties[0]) 
+                << (u32)std::stoi(properties[1]) 
+                << (u8 )std::stoi(properties[2]);
+        
+    }
 
     void verifyPropertyCount();
 };

--- a/src/CYObject.h
+++ b/src/CYObject.h
@@ -43,8 +43,12 @@ enum class ObjectID : uint8_t {
  * 
  */
 struct Position {
-    int x = 0;
+    int16_t x = 0;
     int z = 0;
+
+    int16_t serialize() {
+
+    }
 };
 
 /**

--- a/src/CYObject.h
+++ b/src/CYObject.h
@@ -50,7 +50,7 @@ struct Position {
 
     template<typename Buffer>
     void serialize(Buffer& buffer) const {
-        buffer << (u16)x << (u16)z;
+        buffer << (i16)x << (i16)z;
     }
 };
 
@@ -81,8 +81,9 @@ struct CYWall {
  */
 struct CYObject {
     Position position; 
-    std::vector<std::string> properties;
     uint8_t floor;
+
+    std::vector<std::string> properties;
 
     void serialize(BinaryFileBuffer& buffer) const;
     void verifyPropertyCount(ObjectID id);
@@ -101,6 +102,13 @@ struct CYLevel {
     CYObjectMap objects;
     std::vector<CYFloor> floors;
     std::vector<CYWall> walls;
+
+    size_t numObjects(ObjectID id) const {
+        return objects.at(id).size();
+    }
 };
 
 ObjectID stringToObjectID(const std::string& objectName);
+
+
+void serializeObject(BinaryFileBuffer& buffer, ObjectID id);

--- a/src/CYObject.h
+++ b/src/CYObject.h
@@ -110,6 +110,3 @@ struct CYLevel {
 };
 
 ObjectID stringToObjectID(const std::string& objectName);
-
-
-void serializeObject(BinaryFileBuffer& buffer, ObjectID id);

--- a/src/CYObject.h
+++ b/src/CYObject.h
@@ -54,6 +54,27 @@ struct Position {
     }
 };
 
+struct CYFloor {
+    Position vertexA;
+    Position vertexB;
+    Position vertexC;
+    Position vertexD;
+    uint8_t floor;
+    std::vector<std::string> properties;
+
+    void serialize(BinaryFileBuffer& buffer) const;
+};
+
+struct CYWall {
+    Position beginPoint;
+    Position endPoint;
+    std::vector<std::string> properties;
+    uint8_t floor;
+
+    void serialize(BinaryFileBuffer& buffer) const;
+    void verifyPropertyCount();
+};
+
 /**
  * @brief Represents a single CY Object
  * 
@@ -63,34 +84,8 @@ struct CYObject {
     std::vector<std::string> properties;
     uint8_t floor;
 
+    void serialize(BinaryFileBuffer& buffer) const;
     void verifyPropertyCount(ObjectID id);
-};
-
-struct CYFloor {
-    Position vertexA;
-    Position vertexB;
-    Position vertexC;
-    Position vertexD;
-    uint8_t floor;
-    std::vector<std::string> properties;
-};
-
-struct CYWall {
-    Position beginPoint;
-    Position endPoint;
-    std::vector<std::string> properties;
-    uint8_t floor;
-
-    template<typename Buffer>
-    void serialize(Buffer& buffer) const {
-        buffer  << beginPoint << endPoint << floor
-                << (u32)std::stoi(properties[0]) 
-                << (u32)std::stoi(properties[1]) 
-                << (u8 )std::stoi(properties[2]);
-        
-    }
-
-    void verifyPropertyCount();
 };
 
 using CYObjectMap = std::unordered_map<ObjectID, std::vector<CYObject>>;

--- a/src/CYObject.h
+++ b/src/CYObject.h
@@ -49,8 +49,7 @@ struct Position {
     int x = 0;
     int z = 0;
 
-    template<typename Buffer>
-    void serialize(Buffer& buffer) const {
+    void serialize(BinaryFileBuffer& buffer) const {
         buffer << (i16)x << (i16)z;
     }
 };

--- a/src/CYObject.h
+++ b/src/CYObject.h
@@ -71,8 +71,8 @@ struct CYFloor {
     Position vertexB;
     Position vertexC;
     Position vertexD;
-    std::vector<std::string> properties;
     uint8_t floor;
+    std::vector<std::string> properties;
 };
 
 struct CYWall {
@@ -83,7 +83,7 @@ struct CYWall {
 
     template<typename Buffer>
     void serialize(Buffer& buffer) const {
-        buffer << beginPoint << endPoint << floor
+        buffer  << beginPoint << endPoint << floor
                 << (u32)std::stoi(properties[0]) 
                 << (u32)std::stoi(properties[1]) 
                 << (u8 )std::stoi(properties[2]);

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -254,6 +254,9 @@ std::optional<CYLevel> parseFile(const char* fileName) {
                         } else {
                             object.properties[1] = std::to_string(convertTexture(objId, object.properties[1]));
                         }
+                        if (objId == ObjectID::DiaPlatform) {
+                            std::cout << object.properties[1] << '\n';
+                        }
                     }
 
                     objects.push_back(object);

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -221,6 +221,12 @@ std::optional<CYLevel> parseFile(const char* fileName) {
                             object.properties = extractPropertiesMessage(d.substr(s[i + 1].first, s[i + 1].second));
                             break;
 
+                        //Some objects had a pointless first property
+                        case ObjectID::Key:
+                        case ObjectID::Teleport:
+                            object.properties.push_back(extractProperties(d.substr(s[i + 1].first, s[i + 1].second))[1]);
+                            break;
+
                         default: 
                             object.properties = extractProperties(d.substr(s[i + 1].first, s[i + 1].second));
                             break;

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -268,7 +268,7 @@ std::optional<CYLevel> parseFile(const char* fileName) {
                         break;
 
                     default:
-                        level.objects.emplace(objId, std::move(objects));
+                        level.objects[(int)objId] = std::move(objects);
                         break;
 
                 }

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -255,7 +255,6 @@ std::optional<CYLevel> parseFile(const char* fileName) {
                             object.properties[1] = std::to_string(convertTexture(objId, object.properties[1]));
                         }
                         if (objId == ObjectID::DiaPlatform) {
-                            std::cout << object.properties[1] << '\n';
                         }
                     }
 
@@ -280,8 +279,8 @@ std::optional<CYLevel> parseFile(const char* fileName) {
 }
 
 void printErrors() {
-    std::cout << "\n=======================================\n";
-    std::cout << "Printing all error levels came across: \n";
+    std::cout   << "\n=======================================\n"
+                << "Printing all error levels came across: \n";
     for (const auto& error : errors) {
         std::cout   << "File: " << error.name << "\n"
                     << "\tReason: " << error.reason << "\n\n";

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -170,6 +170,8 @@ std::optional<CYLevel> parseFile(const char* fileName) {
                     floor.vertexC = extractPosition(getMatchSection(s[i + 2], d));
                     floor.vertexD = extractPosition(getMatchSection(s[i + 3], d));
                     floor.properties = extractProperties(d.substr(s[i + 6].first, s[i + 6].second));
+                    floor.properties[0] = std::to_string(convertTexture(objId, floor.properties[0]));
+                    floor.properties[2] = std::to_string(convertTexture(objId, floor.properties[2]));
                     floor.floor = ++floorNumber;
                     floors.push_back(floor);
                 }

--- a/src/FileWriter.cpp
+++ b/src/FileWriter.cpp
@@ -29,8 +29,7 @@ namespace {
 
     void writeSingleObjectHeader(BinaryFileBuffer& buffer, const Position& position, uint8_t floor) {
         buffer << position << (u8)floor;
-    }
-    
+    }    
 }
 
 void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
@@ -40,12 +39,14 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
             << (u8)std::stoi(level.numFloors)
             << (u8)level.backmusic << (u8)level.theme << (u8)level.weather;
 
-    //WALLS
+    //Walls
     writeObjectTypeHeader(bBuffer, ObjectID::Wall, level.walls.size(), 
         {PType::Texture, PType::Texture, PType::QValue});
     for (const auto& wall : level.walls) {
         bBuffer << wall;
     } 
+
+    //Floors
             
     //Final output
     std::ofstream outfile3(fileName + "_v2", std::ofstream::binary);

--- a/src/FileWriter.cpp
+++ b/src/FileWriter.cpp
@@ -2,8 +2,12 @@
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
+#include <vector>
 
 #include "CYObject.h"
+#include "BinaryFile.h"
+#include "Benchmark.h"
 
 namespace {
     enum class PType : uint8_t {
@@ -16,84 +20,34 @@ namespace {
         Unknown     = 250,
     };
 
-    template<typename WriteType, typename OrigType>
-    void writeNumber(std::ofstream& outFile, OrigType n) {
-        WriteType converted = static_cast<WriteType>(n);
-        outFile.write(reinterpret_cast<const char*>(&converted), sizeof(converted));
-    }
-
-    void writeString(std::ofstream& outFile, const std::string& string) {
-        auto size = (uint16_t)string.size();
-        writeNumber<uint16_t>(outFile, size);
-        outFile.write(reinterpret_cast<const char*>(&size), sizeof(size));
-        outFile.write(string.c_str(), string.size());
-    }
-
-    void writeObjectTypeHeader(std::ofstream& outFile, const std::initializer_list<PType>& format, ObjectID id, size_t numObjects) {
-        writeNumber<uint8_t>(outFile, id);
-        writeNumber<uint8_t>(outFile, format.size());
-        for (auto p : format) {
-            writeNumber<uint8_t>(outFile, p);
-        }
-        
-        writeNumber<uint32_t>(outFile, numObjects);
-    }
-
-    void writePosition(std::ofstream& outFile, const Position& position) {
-        auto x = position.x;
-        auto z = position.z;
-
-        writeNumber<int16_t>(outFile, x);
-        writeNumber<int16_t>(outFile, z);
-    }
-
-    void writeSingleObjectHeader(std::ofstream& outFile, const Position& position, uint8_t floor) {
-        writePosition(outFile, position);
-        writeNumber<uint8_t>(outFile, floor);
-    }
-
-    void writeWalls(std::ofstream& outFile, const std::vector<CYWall>& walls) {
-        writeObjectTypeHeader(
-            outFile, 
-            {PType::Texture, PType::Texture, PType::QValue}, 
-            ObjectID::Wall, walls.size());
-
-        for (const auto& wall : walls) {
-            writePosition(outFile, wall.beginPoint);
-            writePosition(outFile, wall.endPoint);
-            writeNumber<uint8_t>(outFile, wall.floor);
-            writeNumber<uint32_t>(outFile, std::stoi(wall.properties[0]));
-            writeNumber<uint32_t>(outFile, std::stoi(wall.properties[1]));
-            writeNumber<uint8_t>(outFile, std::stoi(wall.properties[2]));
+    void writeObjectTypeHeader(BinaryFileBuffer& buffer, ObjectID id, size_t numObjects, const std::initializer_list<PType>& format) {
+        buffer << (u8)id << (u8)format.size() << (u32)numObjects;
+        for (auto& property : format) {
+            buffer << (u8)property;
         }
     }
 
-    void writeFloors(std::ofstream& outFile, const std::vector<CYFloor>& floors) {
-        writeObjectTypeHeader(
-            outFile,
-            {PType::Texture, PType::IsHidden, PType::Texture},
-            ObjectID::Floor, floors.size());
-        for (const auto& floor : floors) {
-            writePosition(outFile, floor.vertexA);
-            writePosition(outFile, floor.vertexA);
-            writePosition(outFile, floor.vertexA);
-            writePosition(outFile, floor.vertexA);
-        }
+    void writeSingleObjectHeader(BinaryFileBuffer& buffer, const Position& position, uint8_t floor) {
+        buffer << position << (u8)floor;
     }
+    
 }
 
-
 void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
-    std::ofstream outfile(fileName, std::ofstream::binary);
+    BinaryFileBuffer bBuffer;
+    bBuffer << (u8)1 
+            << level.name << level.creator 
+            << (u8)std::stoi(level.numFloors)
+            << (u8)level.backmusic << (u8)level.theme << (u8)level.weather;
 
-    writeNumber<uint16_t>(outfile, 1); //Version number
-    writeString(outfile, level.name);
-    writeString(outfile, level.creator);
-    writeNumber<uint8_t>(outfile, std::stoi(level.numFloors));
-    writeNumber<uint8_t>(outfile, level.backmusic);
-    writeNumber<uint8_t>(outfile, level.theme);
-    writeNumber<uint8_t>(outfile, level.weather);
-
-    writeWalls(outfile, level.walls);
-    writeFloors(outfile, level.floors);
+    //WALLS
+    writeObjectTypeHeader(bBuffer, ObjectID::Wall, level.walls.size(), 
+        {PType::Texture, PType::Texture, PType::QValue});
+    for (const auto& wall : level.walls) {
+        bBuffer << wall;
+    } 
+            
+    //Final output
+    std::ofstream outfile3(fileName + "_v2", std::ofstream::binary);
+    outfile3.write(bBuffer.getBuffer(), bBuffer.bufferSize());
 }

--- a/src/FileWriter.cpp
+++ b/src/FileWriter.cpp
@@ -25,6 +25,7 @@ namespace {
         KeyID       = 11,   //Key to doors
         Speed       = 12,   //Icemen speed
         Strength    = 13,   //Icemen strength
+        ChaserStyle = 14,   //Chasers can be saucer, pumpkin, or ghost
         DiamondType = 14,   //Diamonds have different types
     };  
 
@@ -112,7 +113,8 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     } 
 
     //Chaser		
-    
+    writeAllU8Group(bBuffer, level, ObjectID::Chaser, 
+        {PType::Speed, PType::ChaserStyle});
     //Crumbs	
     writeAllU8Group(bBuffer, level, ObjectID::Crumbs, 
         {PType::Amount});

--- a/src/FileWriter.cpp
+++ b/src/FileWriter.cpp
@@ -16,10 +16,11 @@ namespace {
         IsHidden    = 2, //For floors, whether or not it is hidden or not
         Size        = 3, //Resizable objects such as all platforms, and pillars
         Direction   = 4, //Directional objects such as triplats, boards, ramps etc
-        Message     = 5, //For objects that have a string (eg Portal and Board)
-        Flip        = 6, //For objects that have a binary option eg pillars stright or dia, or triwalls flip
+        Message     = 5, //String (eg Portal and Board)
+        Flip        = 6, //binary geometry option eg pillars stright or dia, or triwalls flip
         FuelType    = 7, //For JetPacks; Whether the jetpack needs fuel or nah
         WinCond     = 8, //Win condition, such as portals and finish marker
+        Amount      = 9, //Objects such as crumbs, sheilds, and fuel allow you to choose amount
         Unknown     = 250,
     };
 
@@ -88,7 +89,9 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
 
     //Chaser		
     
-    //Crumbs		
+    //Crumbs	
+    writeObjectGroup(bBuffer, level, ObjectID::Crumbs, 
+        {PType::Amount});
     
     //DiaPlatform	
     writeObjectGroup(bBuffer, level, ObjectID::DiaPlatform, 
@@ -100,9 +103,13 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     
     //Finish		
     
-    //Fuel		
+    //Fuel	
+    writeObjectGroup(bBuffer, level, ObjectID::Fuel, 
+        {PType::Amount});	
     
     //Hole		
+    writeObjectGroup(bBuffer, level, ObjectID::Hole, 
+        {PType::Size});
     
     //Iceman		
     
@@ -111,29 +118,40 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     //Key		    
     
     //Ladder		
+    writeObjectGroup(bBuffer, level, ObjectID::Ladder, 
+        {PType::Direction});
     
     //Message		
-    
+    writeObjectGroup(bBuffer, level, ObjectID::Message, 
+        {PType::Message, PType::Direction, PType::QValue});
+
     //Pillar
-    writeObjectGroup(bBuffer, level, ObjectID::Platform, 
+    writeObjectGroup(bBuffer, level, ObjectID::Pillar, 
         {PType::Flip, PType::Texture, PType::Size, PType::QValue});
     
     //Platform	
     writeObjectGroup(bBuffer, level, ObjectID::Platform, 
         {PType::Size, PType::Texture, PType::QValue});
     
-
-    //Portal		
+    //Portal	
+    writeObjectGroup(bBuffer, level, ObjectID::Portal, 
+        {PType::Message, PType::WinCond, PType::Message});
     
     //Ramp	
     writeObjectGroup(bBuffer, level, ObjectID::Ramp, 
         {PType::Direction, PType::Texture});	
     
-    //Shield		
+    //Shield	
+    writeObjectGroup(bBuffer, level, ObjectID::Shield, 
+        {PType::Amount});		
     
     //Slingshot	
+    writeObjectGroup(bBuffer, level, ObjectID::Slingshot, 
+        {PType::QValue});	
     
     //Start		
+    writeObjectGroup(bBuffer, level, ObjectID::Start, 
+        {PType::Direction});	
     
     //Teleport	
 
@@ -146,7 +164,20 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
         {PType::Flip, PType::Texture, PType::Direction});	
 
 
-    //Final output
-    std::ofstream outfile3(fileName + "_v2", std::ofstream::binary);
+    //Final output and create a filename to output as
+    auto pathidx = [&fileName]() {
+        for (size_t i = 0; i < fileName.size(); i++) {
+            if (std::isdigit(fileName[i])) {
+                return i;
+            }
+        }
+        return std::string::npos;
+    }();
+    auto path = fileName.substr(0, pathidx);
+    auto gameNumber = fileName.substr(pathidx);
+    gameNumber = gameNumber.substr(0, gameNumber.find('.'));
+    auto outputName = path + level.name + "[" + gameNumber + "].cyb";
+
+    std::ofstream outfile3(outputName, std::ofstream::binary);
     outfile3.write(bBuffer.getBuffer(), bBuffer.bufferSize());
 }

--- a/src/FileWriter.cpp
+++ b/src/FileWriter.cpp
@@ -21,13 +21,12 @@ namespace {
         FuelType    = 7, //For JetPacks; Whether the jetpack needs fuel or nah
         WinCond     = 8, //Win condition, such as portals and finish marker
         Amount      = 9, //Objects such as crumbs, sheilds, and fuel allow you to choose amount
-        TeleID      = 10, //Keys, doors, locks, teleports
-        KeyID       = 11,
-        Speed       = 12,
-        Strength    = 13,
-        DiamondType = 14,
-        Unknown     = 250,
-    };
+        TeleID      = 10,   //Teleports connect to eachother
+        KeyID       = 11,   //Key to doors
+        Speed       = 12,   //Icemen speed
+        Strength    = 13,   //Icemen strength
+        DiamondType = 14,   //Diamonds have different types
+    };  
 
     //Writes header info about an object
     void writeObjectTypeHeader(BinaryFileBuffer& buffer, ObjectID id, 

--- a/src/FileWriter.cpp
+++ b/src/FileWriter.cpp
@@ -37,12 +37,30 @@ namespace {
         buffer << position << (u8)floor;
     }
 
+    void writeAllU8Group(BinaryFileBuffer& buffer, const CYLevel& level, 
+            ObjectID id, const std::initializer_list<PType>& format)
+    {
+        if (level.numObjects(id)) {
+            writeObjectTypeHeader(buffer, id, level.numObjects(id), format);
+            for (const auto& obj : level.objects[(int)id]) {
+                writeSingleObjectHeader(buffer, obj.position, obj.floor);
+                const auto& props = obj.properties;
+                size_t index = 0;
+                for (auto ptype : format) {
+                    buffer << (u8)std::stoi(props[index]);
+                    index++;
+                }
+            }
+        }
+    }
+
     void writeObjectGroup(BinaryFileBuffer& buffer, const CYLevel& level, 
             ObjectID id, const std::initializer_list<PType>& format) 
     {
         if (level.numObjects(id)) {
             writeObjectTypeHeader(buffer, id, level.numObjects(id), format);
             for (const auto& obj : level.objects[(int)id]) {
+                writeSingleObjectHeader(buffer, obj.position, obj.floor);
                 const auto& props = obj.properties;
                 size_t index = 0;
                 for (auto ptype : format) {
@@ -90,7 +108,7 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     //Chaser		
     
     //Crumbs	
-    writeObjectGroup(bBuffer, level, ObjectID::Crumbs, 
+    writeAllU8Group(bBuffer, level, ObjectID::Crumbs, 
         {PType::Amount});
     
     //DiaPlatform	
@@ -104,11 +122,11 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     //Finish		
     
     //Fuel	
-    writeObjectGroup(bBuffer, level, ObjectID::Fuel, 
+    writeAllU8Group(bBuffer, level, ObjectID::Fuel, 
         {PType::Amount});	
     
     //Hole		
-    writeObjectGroup(bBuffer, level, ObjectID::Hole, 
+    writeAllU8Group(bBuffer, level, ObjectID::Hole, 
         {PType::Size});
     
     //Iceman		
@@ -118,7 +136,7 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     //Key		    
     
     //Ladder		
-    writeObjectGroup(bBuffer, level, ObjectID::Ladder, 
+    writeAllU8Group(bBuffer, level, ObjectID::Ladder, 
         {PType::Direction});
     
     //Message		
@@ -142,15 +160,15 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
         {PType::Direction, PType::Texture});	
     
     //Shield	
-    writeObjectGroup(bBuffer, level, ObjectID::Shield, 
+    writeAllU8Group(bBuffer, level, ObjectID::Shield, 
         {PType::Amount});		
     
     //Slingshot	
-    writeObjectGroup(bBuffer, level, ObjectID::Slingshot, 
+    writeAllU8Group(bBuffer, level, ObjectID::Slingshot, 
         {PType::QValue});	
     
     //Start		
-    writeObjectGroup(bBuffer, level, ObjectID::Start, 
+    writeAllU8Group(bBuffer, level, ObjectID::Start, 
         {PType::Direction});	
     
     //Teleport	

--- a/src/FileWriter.cpp
+++ b/src/FileWriter.cpp
@@ -11,11 +11,12 @@
 
 namespace {
     enum class PType : uint8_t {
-        Position    = 0,
-        Texture     = 1,
-        QValue      = 2,
-        Floor       = 3,
-        IsHidden    = 4,
+        Texture     = 0,
+        QValue      = 1,
+        Floor       = 2,
+        IsHidden    = 3,
+        Size        = 4,
+        Direction   = 5,
 
         Unknown     = 250,
     };
@@ -25,11 +26,7 @@ namespace {
         for (auto& property : format) {
             buffer << (u8)property;
         }
-    }
-
-    void writeSingleObjectHeader(BinaryFileBuffer& buffer, const Position& position, uint8_t floor) {
-        buffer << position << (u8)floor;
-    }    
+    }   
 }
 
 void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
@@ -47,7 +44,60 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     } 
 
     //Floors
-            
+    writeObjectTypeHeader(bBuffer, ObjectID::Floor, level.floors.size(), 
+        {PType::Texture, PType::Texture, PType::IsHidden});
+    for (const auto& floor : level.floors) {
+        bBuffer << floor;
+    } 
+
+    //Chaser		
+    
+    //Crumbs		
+    
+    //DiaPlatform	
+    
+    //Diamond		
+    
+    //Door	
+    
+    //Finish		
+    
+    //Fuel		
+    
+    //Hole		
+    
+    //Iceman		
+    
+    //JetPack		
+    
+    //Key		    
+    
+    //Ladder		
+    
+    //Message		
+    
+    //Pillar		
+    
+    //Platform	
+    
+    //Portal		
+    
+    //Ramp		
+    
+    //Shield		
+    
+    //Slingshot	
+    
+    //Start		
+    
+    //Teleport	
+    
+    //TriPlatform 
+    
+    //TriWall		
+   //// writeObjectTypeHeader(bBuffer, ObjectID::TriPlatform, level.numObjects(ObjectID::TriPlatform), 
+    //    {PType::Size, PType::Texture, PType::Direction});
+
     //Final output
     std::ofstream outfile3(fileName + "_v2", std::ofstream::binary);
     outfile3.write(bBuffer.getBuffer(), bBuffer.bufferSize());

--- a/src/FileWriter.cpp
+++ b/src/FileWriter.cpp
@@ -11,14 +11,15 @@
 
 namespace {
     enum class PType : uint8_t {
-        Texture     = 0,
-        QValue      = 1,
-        Floor       = 2,
-        IsHidden    = 3,
-        Size        = 4,
-        Direction   = 5,
-        Message     = 6,
-
+        Texture     = 0, //Texture
+        QValue      = 1, //The "height" of objects, eg walls and platforms 
+        IsHidden    = 2, //For floors, whether or not it is hidden or not
+        Size        = 3, //Resizable objects such as all platforms, and pillars
+        Direction   = 4, //Directional objects such as triplats, boards, ramps etc
+        Message     = 5, //For objects that have a string (eg Portal and Board)
+        Flip        = 6, //For objects that have a binary option eg pillars stright or dia, or triwalls flip
+        FuelType    = 7, //For JetPacks; Whether the jetpack needs fuel or nah
+        WinCond     = 8, //Win condition, such as portals and finish marker
         Unknown     = 250,
     };
 
@@ -90,7 +91,9 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     //Crumbs		
     
     //DiaPlatform	
-    
+    writeObjectGroup(bBuffer, level, ObjectID::DiaPlatform, 
+        {PType::Size, PType::Texture, PType::QValue});
+
     //Diamond		
     
     //Door	
@@ -111,7 +114,9 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     
     //Message		
     
-    //Pillar		
+    //Pillar
+    writeObjectGroup(bBuffer, level, ObjectID::Platform, 
+        {PType::Flip, PType::Texture, PType::Size, PType::QValue});
     
     //Platform	
     writeObjectGroup(bBuffer, level, ObjectID::Platform, 
@@ -120,7 +125,9 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
 
     //Portal		
     
-    //Ramp		
+    //Ramp	
+    writeObjectGroup(bBuffer, level, ObjectID::Ramp, 
+        {PType::Direction, PType::Texture});	
     
     //Shield		
     
@@ -134,7 +141,9 @@ void writeLevelBinary(const CYLevel& level, const std::string& fileName) {
     writeObjectGroup(bBuffer, level, ObjectID::TriPlatform, 
         {PType::Size, PType::Texture, PType::Direction, PType::QValue});
     
-    //TriWall		
+    //TriWall	
+    writeObjectGroup(bBuffer, level, ObjectID::TriWall, 
+        {PType::Flip, PType::Texture, PType::Direction});	
 
 
     //Final output

--- a/src/TextureConverter.cpp
+++ b/src/TextureConverter.cpp
@@ -53,7 +53,7 @@ namespace {
     }
 
     int32_t convertPlatformTexture(int texture) {
-        switch (texture) // WALLS
+        switch (texture)
         {
             case 1: return  TextureID::Grass;
             case 2: return  TextureID::Stucco;

--- a/src/TextureConverter.cpp
+++ b/src/TextureConverter.cpp
@@ -106,7 +106,7 @@ uint32_t convertTexture(ObjectID object, const std::string& texture) {
 
         default:
             std::cerr << "UNKNOWN OBEJCT";
-            return -1;
+            return TextureID::Unknown;
     }
 
 }

--- a/src/TextureConverter.cpp
+++ b/src/TextureConverter.cpp
@@ -47,11 +47,6 @@ namespace {
         }
     }
 
-    int32_t convertFloorTexture(int texture) {
-
-        return TextureID::None;
-    }
-
     int32_t convertPlatformTexture(int texture) {
         switch (texture)
         {
@@ -109,7 +104,7 @@ int32_t convertTexture(ObjectID object, const std::string& texture) {
         case ObjectID::TriPlatform:
         case ObjectID::DiaPlatform:
         case ObjectID::Ramp:
-            return convertFloorTexture(std::stoi(texture));
+            return convertPlatformTexture(std::stoi(texture));
 
         default:
             std::cerr << "UNKNOWN OBEJCT";

--- a/src/TextureConverter.cpp
+++ b/src/TextureConverter.cpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <functional>
 #include <iostream>
+#include <bitset>
 
 #include "Utilities.h"
 
@@ -14,19 +15,17 @@ namespace {
         return texture.find("color") != std::string::npos;
     }
 
-    int32_t colourToInt(const std::string& texture) {
+    uint32_t colourToInt(const std::string& texture) {
         auto colours = split(texture, ',');
         colours[0] = colours[0].substr(6);
         colours[2].pop_back();
-
-        auto r = std::stoi(colours[0]);
-        auto g = std::stoi(colours[1]);
-        auto b = std::stoi(colours[2]);
-        
-        return r << 16 | g << 8 | b;
+        auto r = (u8)std::stoi(colours[0]);
+        auto g = (u8)std::stoi(colours[1]);
+        auto b = (u8)std::stoi(colours[2]);
+        return (r << 24) | (g << 16) | (b << 8) | 0xFF;
     }
 
-    int32_t convertWallTexture(int texture) {
+    uint32_t convertWallTexture(int texture) {
         switch (texture) {
             case 1: return  TextureID::Brick;
             case 2: return  TextureID::Bars;
@@ -47,9 +46,8 @@ namespace {
         }
     }
 
-    int32_t convertPlatformTexture(int texture) {
-        switch (texture)
-        {
+    uint32_t convertPlatformTexture(int texture) {
+        switch (texture) {
             case 1: return  TextureID::Grass;
             case 2: return  TextureID::Stucco;
             case 3: return  TextureID::Brick;
@@ -87,7 +85,7 @@ bool hasTexture(ObjectID id) {
 }
 
 
-int32_t convertTexture(ObjectID object, const std::string& texture) {
+uint32_t convertTexture(ObjectID object, const std::string& texture) {
     if (isColourTexture(texture)) {
         return colourToInt(texture);
     }
@@ -97,14 +95,14 @@ int32_t convertTexture(ObjectID object, const std::string& texture) {
         case ObjectID::Pillar:
         case ObjectID::Door:
         case ObjectID::TriWall:
-            return convertWallTexture(std::stoi(texture));
+            return convertWallTexture(std::stoul(texture));
 
         case ObjectID::Floor:
         case ObjectID::Platform:
         case ObjectID::TriPlatform:
         case ObjectID::DiaPlatform:
         case ObjectID::Ramp:
-            return convertPlatformTexture(std::stoi(texture));
+            return convertPlatformTexture(std::stoul(texture));
 
         default:
             std::cerr << "UNKNOWN OBEJCT";

--- a/src/TextureConverter.h
+++ b/src/TextureConverter.h
@@ -6,7 +6,7 @@
 //This is not an enum class because of colour textures are represented using 24bits for RGB
 //Layout for colours: 00000000RRRRRRRRGGGGGGGGBBBBBBBB
 namespace TextureID {
-    enum {
+    enum : uint32_t  {
         // Normal Textures
         Grass = 1,
         Stucco = 2,
@@ -26,6 +26,7 @@ namespace TextureID {
         Bars = 14,
         Glass = 15,
         None = 16,
+        Unknown = 17
     };
 }
 

--- a/src/TextureConverter.h
+++ b/src/TextureConverter.h
@@ -30,4 +30,4 @@ namespace TextureID {
 }
 
 bool hasTexture     (ObjectID id);
-int convertTexture  (ObjectID object, const std::string& texture);
+uint32_t convertTexture  (ObjectID object, const std::string& texture);

--- a/src/TextureConverter.h
+++ b/src/TextureConverter.h
@@ -3,8 +3,9 @@
 #include <string>
 #include "CYObject.h"
 
-//This is not an enum class because of colour textures are represented using 24bits for RGB
-//Layout for colours: 00000000RRRRRRRRGGGGGGGGBBBBBBBB
+//This is not an enum class because of colour textures are represented using 32bits for RGBT
+//where T is just 255 in binary to ID this is a texure
+//Layout for colours: RRRRRRRRGGGGGGGGBBBBBBBB11111111
 namespace TextureID {
     enum : uint32_t  {
         // Normal Textures

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,28 +92,35 @@ auto getGamesDirectoryItr() {
 }
 
 int main() {
-    #ifndef USE_SAMPLE_GAMES
+#ifndef USE_SAMPLE_GAMES
     benchmark::Timer<> timer;
     const int percentIncrement = std::distance(getGamesDirectoryItr(), fs::directory_iterator{}) / 100;
     int count = 0;
     int progress = 0;
     std::cout << "Total files: " << percentIncrement * 100 << std::endl;
     timer.reset();
-    #endif
+#endif
     for (const auto& path : getGamesDirectoryItr()) {
-        #ifndef USE_SAMPLE_GAMES
+#ifndef USE_SAMPLE_GAMES
         if (++count % percentIncrement == 0) {
             printf("Progress: %d%% [%d out of %d games converted] ", ++progress, count, percentIncrement * 100);
             printf("[Time: %fms]\n", timer.getTime());
             timer.reset();
         }
-        #endif
+#endif
 
         const std::string name = path.path().filename().string();
         auto level = readFile(path.path().c_str());
         if (level) {
+#ifdef SINGLE_GAME
+            benchmark::Benchmark<100>(std::string(name + ": Binary").c_str(), 
+                &writeLevelBinary, *level, OUT + name + ".cyb").outputTimes();
+            benchmark::Benchmark<100>(std::string(name + ": Text  ").c_str(), 
+                &writeLevel, OUT + name + ".cyb", *level).outputTimes();
+#else 
             writeLevelBinary(*level, OUT + name + ".cyb");
-            writeLevel(name, *level);
+            writeLevel(OUT + name + ".cyb", *level);
+#endif
         }   
     }
     printErrors();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 
 #define USE_SAMPLE_GAMES 
 #ifdef USE_SAMPLE_GAMES
-    //#define SINGLE_GAME
+    #define SINGLE_GAME
     #ifdef SINGLE_GAME
         #define DIR "../../single"
         #define OUT "../../single_out/"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 
 #define USE_SAMPLE_GAMES 
 #ifdef USE_SAMPLE_GAMES
-    #define SINGLE_GAME
+    //#define SINGLE_GAME
     #ifdef SINGLE_GAME
         #define DIR "../../single"
         #define OUT "../../single_out/"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,9 +60,9 @@ void writeLevel(const std::string& name, const CYLevel& level) {
         outfile << "\n\n";               
     }
     
-    for (const auto& cyObject : level.objects) {
-        outfile << "Object ID: " << (int)cyObject.first << '\n';
-        for (const auto& obj : cyObject.second) {
+    for (size_t i = 0; i < level.objects.size(); i++) {
+        outfile << "Object ID: " << i << '\n';
+        for (const auto& obj : level.objects[i]) {
             outfile << "\tPosition:   " << obj.position.x << " " << obj.position.z << '\n'
                     << "\tFloor:      " << (int)obj.floor << '\n'
                     << "\tProperties: ";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,7 +67,12 @@ void writeLevel(const std::string& name, const CYLevel& level) {
                     << "\tFloor:      " << (int)obj.floor << '\n'
                     << "\tProperties: ";
             for (const auto& p : obj.properties) {
-                outfile << p << ' ';
+                if (i == (int)ObjectID::Message) {
+                    outfile << "\n\tMessage Prop: " << p;
+                }
+                else {
+                    outfile << p << ' ';
+                }
             }
             outfile << "\n\n";
         }
@@ -110,16 +115,19 @@ int main() {
 #endif
 
         const std::string name = path.path().filename().string();
+        std::cout << "Doing: " << name << "'\n";
         auto level = readFile(path.path().c_str());
         if (level) {
 #ifdef SINGLE_GAME
-            benchmark::Benchmark<100>(std::string(name + ": Binary").c_str(), 
+#define TIMES 1
+            benchmark::Benchmark<TIMES>(std::string(name + ": Text  ").c_str(), 
+                &writeLevel, name, *level).outputTimes();
+            benchmark::Benchmark<TIMES>(std::string(name + ": Binary").c_str(), 
                 &writeLevelBinary, *level, OUT + name + ".cyb").outputTimes();
-            benchmark::Benchmark<100>(std::string(name + ": Text  ").c_str(), 
-                &writeLevel, OUT + name + ".cyb", *level).outputTimes();
+            std::cout << "\n\n\n\n\n\n\n";
 #else 
             writeLevelBinary(*level, OUT + name + ".cyb");
-            writeLevel(OUT + name + ".cyb", *level);
+            writeLevel(name, *level);
 #endif
         }   
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 
 namespace fs = std::filesystem;
 
-#define USE_SAMPLE_GAMES 
+//#define USE_SAMPLE_GAMES 
 #ifdef USE_SAMPLE_GAMES
     #define SINGLE_GAME
     #ifdef SINGLE_GAME
@@ -115,7 +115,7 @@ int main() {
 #endif
 
         const std::string name = path.path().filename().string();
-        std::cout << "Doing: " << name << "'\n";
+        //std::cout << "Doing: " << name << "'\n";
         auto level = readFile(path.path().c_str());
         if (level) {
 #ifdef SINGLE_GAME
@@ -127,7 +127,7 @@ int main() {
             std::cout << "\n\n\n\n\n\n\n";
 #else 
             writeLevelBinary(*level, OUT + name + ".cyb");
-            writeLevel(name, *level);
+            //writeLevel(name, *level);
 #endif
         }   
     }


### PR DESCRIPTION
The PR allows all the CY files to be converted into a binary file format, which has been standardized across different LevelCrafter versions, making the data A LOT easier and faster to read/parse.